### PR TITLE
Commenting python imports of dtypes to fix build on new machines.

### DIFF
--- a/dag_slicer/dag_slicer.pyx
+++ b/dag_slicer/dag_slicer.pyx
@@ -13,10 +13,8 @@ cimport numpy as np
 from libc.stdlib cimport free
 from libcpp cimport bool as cpp_bool
 from libcpp.string cimport string as std_string
-import dtypes
 from libcpp.vector cimport vector as cpp_vector
 
-import dtypes
 import numpy as np
 
 np.import_array()


### PR DESCRIPTION
Removing python imports of dtypes. Breaks build on fresh installs.
